### PR TITLE
Fix mistery issue.

### DIFF
--- a/scripts/webpack.config.babel.js
+++ b/scripts/webpack.config.babel.js
@@ -16,6 +16,7 @@ export default {
         new webpack.HotModuleReplacementPlugin(),
         new webpack.LoaderOptionsPlugin({
             options: {
+                context: __dirname,
                 postcss: [
                     cssnext({
                         browsers: ['last 2 versions', 'IE > 10'],


### PR DESCRIPTION
Hi, I fall into the same issue that css-loader generates exactly same hash for styles in different file. After debugging, I found that LoaderOptionsPlugin won't inherit context and pass it to css-loader.
A possible patch is to add context for them. See the PR for details.
Hope it helps!